### PR TITLE
add Prometheus, Grafana and Alertmanager monitoring stack

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,3 +9,7 @@
 
 # Podman rootless on macOS:
 # DOCKER_SOCKET=/var/run/docker.sock  (podman machine creates a compat socket here)
+
+# Grafana admin credentials (defaults to admin/admin if not set).
+# GF_SECURITY_ADMIN_USER=admin
+# GF_SECURITY_ADMIN_PASSWORD=admin

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -152,6 +152,61 @@ services:
       retries: 3
       start_period: 5s
 
+  # ── Monitoring stack ─────────────────────────────────────────────────────────
+
+  prometheus:
+    image: prom/prometheus:v3.3.0
+    container_name: prometheus
+    command:
+      - --config.file=/etc/prometheus/prometheus.yml
+      - --web.enable-lifecycle
+      - --storage.tsdb.retention.time=7d
+    volumes:
+      - ./monitoring/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - ./monitoring/prometheus/rules:/etc/prometheus/rules:ro
+    ports:
+      - "9090:9090"
+    networks:
+      - global-net
+    depends_on:
+      global-envoy:
+        condition: service_healthy
+      zone1-envoy:
+        condition: service_healthy
+      zone2-envoy:
+        condition: service_healthy
+
+  alertmanager:
+    image: prom/alertmanager:v0.28.1
+    container_name: alertmanager
+    command:
+      - --config.file=/etc/alertmanager/alertmanager.yml
+      - --web.listen-address=:9093
+    volumes:
+      - ./monitoring/alertmanager/alertmanager.yml:/etc/alertmanager/alertmanager.yml:ro
+    ports:
+      - "9093:9093"
+    networks:
+      - global-net
+
+  grafana:
+    image: grafana/grafana:11.6.1
+    container_name: grafana
+    environment:
+      - GF_SECURITY_ADMIN_USER=${GF_SECURITY_ADMIN_USER:-admin}
+      - GF_SECURITY_ADMIN_PASSWORD=${GF_SECURITY_ADMIN_PASSWORD:-admin}
+      - GF_USERS_ALLOW_SIGN_UP=false
+      - GF_DASHBOARDS_DEFAULT_HOME_DASHBOARD_PATH=/var/lib/grafana/dashboards/traffic-geo.json
+    volumes:
+      - ./monitoring/grafana/provisioning:/etc/grafana/provisioning:ro
+      - ./monitoring/grafana/dashboards:/var/lib/grafana/dashboards:ro
+    ports:
+      - "3000:3000"
+    networks:
+      - global-net
+    depends_on:
+      - prometheus
+
   # ── Tools (profile: tools) ───────────────────────────────────────────────────
   # Run with:  docker compose --profile tools run --rm traffic-gen [flags]
   #            docker compose --profile tools run --rm failure-runner zone1-full

--- a/monitoring/alertmanager/alertmanager.yml
+++ b/monitoring/alertmanager/alertmanager.yml
@@ -1,0 +1,42 @@
+global:
+  resolve_timeout: 5m
+
+# Маршрутизация: critical → отдельная группа с быстрым group_wait
+route:
+  group_by: ['alertname', 'severity']
+  group_wait: 10s
+  group_interval: 1m
+  repeat_interval: 1h
+  receiver: 'default'
+  routes:
+    - matchers:
+        - severity = "critical"
+      group_wait: 5s
+      repeat_interval: 15m
+      receiver: 'critical'
+
+receivers:
+  # Алерты видны в Alertmanager UI: http://localhost:9093
+  # и в Grafana: http://localhost:3000/alerting
+  # Для подключения Slack/PagerDuty — раскомментируй нужный блок ниже.
+  - name: 'default'
+    # slack_configs:
+    #   - api_url: 'https://hooks.slack.com/services/XXX/YYY/ZZZ'
+    #     channel: '#traffic-alerts'
+    #     title: '[{{ .Status | toUpper }}] {{ .GroupLabels.alertname }}'
+    #     text: '{{ range .Alerts }}{{ .Annotations.description }}{{ end }}'
+
+  - name: 'critical'
+    # slack_configs:
+    #   - api_url: 'https://hooks.slack.com/services/XXX/YYY/ZZZ'
+    #     channel: '#incidents'
+    #     title: '[CRITICAL] {{ .GroupLabels.alertname }}'
+    #     text: '{{ range .Alerts }}{{ .Annotations.description }}\nRunbook: {{ .Annotations.runbook }}{{ end }}'
+
+inhibit_rules:
+  # Если RollbackRequired активен — подавляем HighErrorRate (дублирующий)
+  - source_matchers:
+      - alertname = "RollbackRequired"
+    target_matchers:
+      - alertname = "HighErrorRate"
+    equal: ['job']

--- a/monitoring/grafana/dashboards/traffic-geo.json
+++ b/monitoring/grafana/dashboards/traffic-geo.json
@@ -1,0 +1,473 @@
+{
+  "annotations": { "list": [] },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "refresh": "10s",
+  "schemaVersion": 39,
+  "tags": ["envoy", "geo", "traffic"],
+  "time": { "from": "now-30m", "to": "now" },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Geo-Distributed Gateway",
+  "uid": "traffic-geo",
+  "version": 1,
+  "panels": [
+    {
+      "id": 1,
+      "type": "stat",
+      "title": "RPS (global)",
+      "gridPos": { "x": 0, "y": 0, "w": 6, "h": 4 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "sum(rate(envoy_http_downstream_rq_total{job=\"envoy-global\",envoy_http_conn_manager_prefix=\"ingress_http\"}[1m]))",
+          "refId": "A",
+          "instant": true,
+          "legendFormat": "RPS"
+        }
+      ],
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"] },
+        "orientation": "auto",
+        "textMode": "value",
+        "colorMode": "background",
+        "graphMode": "area"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "decimals": 1,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "red", "value": null },
+              { "color": "yellow", "value": 10 },
+              { "color": "green", "value": 50 }
+            ]
+          },
+          "color": { "mode": "thresholds" }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 2,
+      "type": "stat",
+      "title": "Error Rate (5xx %)",
+      "gridPos": { "x": 6, "y": 0, "w": 6, "h": 4 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "sum(rate(envoy_http_downstream_rq_xx{job=\"envoy-global\",envoy_http_conn_manager_prefix=\"ingress_http\",envoy_response_code_class=\"5\"}[2m])) / sum(rate(envoy_http_downstream_rq_total{job=\"envoy-global\",envoy_http_conn_manager_prefix=\"ingress_http\"}[2m])) * 100",
+          "refId": "A",
+          "instant": true,
+          "legendFormat": "error rate"
+        }
+      ],
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"] },
+        "orientation": "auto",
+        "textMode": "value",
+        "colorMode": "background",
+        "graphMode": "area"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "decimals": 2,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 1 },
+              { "color": "red", "value": 5 }
+            ]
+          },
+          "color": { "mode": "thresholds" }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 3,
+      "type": "stat",
+      "title": "p99 Latency (ms)",
+      "gridPos": { "x": 12, "y": 0, "w": 6, "h": 4 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.99, sum(rate(envoy_http_downstream_rq_time_bucket{job=\"envoy-global\",envoy_http_conn_manager_prefix=\"ingress_http\"}[5m])) by (le))",
+          "refId": "A",
+          "instant": true,
+          "legendFormat": "p99"
+        }
+      ],
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"] },
+        "orientation": "auto",
+        "textMode": "value",
+        "colorMode": "background",
+        "graphMode": "area"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ms",
+          "decimals": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 200 },
+              { "color": "red", "value": 500 }
+            ]
+          },
+          "color": { "mode": "thresholds" }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 4,
+      "type": "stat",
+      "title": "Failover Active (ejected endpoints)",
+      "gridPos": { "x": 18, "y": 0, "w": 6, "h": 4 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "sum(envoy_cluster_outlier_detection_ejections_active{job=\"envoy-global\",envoy_cluster_name=\"geo_cluster\"})",
+          "refId": "A",
+          "instant": true,
+          "legendFormat": "ejected"
+        }
+      ],
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"] },
+        "orientation": "auto",
+        "textMode": "value",
+        "colorMode": "background"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "decimals": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "red", "value": 1 }
+            ]
+          },
+          "color": { "mode": "thresholds" },
+          "mappings": [
+            {
+              "type": "value",
+              "options": {
+                "0": { "text": "OK", "color": "green", "index": 0 }
+              }
+            }
+          ]
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 5,
+      "type": "timeseries",
+      "title": "RPS по зонам",
+      "gridPos": { "x": 0, "y": 4, "w": 12, "h": 8 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "sum(rate(envoy_http_downstream_rq_total{job=\"envoy-global\",envoy_http_conn_manager_prefix=\"ingress_http\"}[1m]))",
+          "refId": "A",
+          "legendFormat": "global (total)"
+        },
+        {
+          "expr": "sum(rate(envoy_http_downstream_rq_total{job=\"envoy-zone1\",envoy_http_conn_manager_prefix=\"zone1_ingress\"}[1m]))",
+          "refId": "B",
+          "legendFormat": "zone1"
+        },
+        {
+          "expr": "sum(rate(envoy_http_downstream_rq_total{job=\"envoy-zone2\",envoy_http_conn_manager_prefix=\"zone2_ingress\"}[1m]))",
+          "refId": "C",
+          "legendFormat": "zone2"
+        }
+      ],
+      "options": {
+        "tooltip": { "mode": "multi", "sort": "desc" },
+        "legend": { "displayMode": "list", "placement": "bottom" }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 10,
+            "spanNulls": false
+          }
+        },
+        "overrides": [
+          {
+            "matcher": { "id": "byName", "options": "global (total)" },
+            "properties": [{ "id": "color", "value": { "fixedColor": "blue", "mode": "fixed" } }]
+          },
+          {
+            "matcher": { "id": "byName", "options": "zone1" },
+            "properties": [{ "id": "color", "value": { "fixedColor": "green", "mode": "fixed" } }]
+          },
+          {
+            "matcher": { "id": "byName", "options": "zone2" },
+            "properties": [{ "id": "color", "value": { "fixedColor": "orange", "mode": "fixed" } }]
+          }
+        ]
+      }
+    },
+    {
+      "id": 6,
+      "type": "timeseries",
+      "title": "Error Rate по зонам (%)",
+      "gridPos": { "x": 12, "y": 4, "w": 12, "h": 8 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "sum(rate(envoy_http_downstream_rq_xx{job=\"envoy-global\",envoy_http_conn_manager_prefix=\"ingress_http\",envoy_response_code_class=\"5\"}[1m])) / sum(rate(envoy_http_downstream_rq_total{job=\"envoy-global\",envoy_http_conn_manager_prefix=\"ingress_http\"}[1m])) * 100",
+          "refId": "A",
+          "legendFormat": "global 5xx %"
+        },
+        {
+          "expr": "sum(rate(envoy_http_downstream_rq_xx{job=\"envoy-zone1\",envoy_http_conn_manager_prefix=\"zone1_ingress\",envoy_response_code_class=\"5\"}[1m])) / sum(rate(envoy_http_downstream_rq_total{job=\"envoy-zone1\",envoy_http_conn_manager_prefix=\"zone1_ingress\"}[1m])) * 100",
+          "refId": "B",
+          "legendFormat": "zone1 5xx %"
+        },
+        {
+          "expr": "sum(rate(envoy_http_downstream_rq_xx{job=\"envoy-zone2\",envoy_http_conn_manager_prefix=\"zone2_ingress\",envoy_response_code_class=\"5\"}[1m])) / sum(rate(envoy_http_downstream_rq_total{job=\"envoy-zone2\",envoy_http_conn_manager_prefix=\"zone2_ingress\"}[1m])) * 100",
+          "refId": "C",
+          "legendFormat": "zone2 5xx %"
+        }
+      ],
+      "options": {
+        "tooltip": { "mode": "multi", "sort": "desc" },
+        "legend": { "displayMode": "list", "placement": "bottom" }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "min": 0,
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 15,
+            "spanNulls": false
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 1 },
+              { "color": "red", "value": 5 }
+            ]
+          },
+          "color": { "mode": "thresholds" }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 7,
+      "type": "timeseries",
+      "title": "Latency percentiles — global-envoy (ms)",
+      "gridPos": { "x": 0, "y": 12, "w": 12, "h": 8 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.50, sum(rate(envoy_http_downstream_rq_time_bucket{job=\"envoy-global\",envoy_http_conn_manager_prefix=\"ingress_http\"}[5m])) by (le))",
+          "refId": "A",
+          "legendFormat": "p50"
+        },
+        {
+          "expr": "histogram_quantile(0.95, sum(rate(envoy_http_downstream_rq_time_bucket{job=\"envoy-global\",envoy_http_conn_manager_prefix=\"ingress_http\"}[5m])) by (le))",
+          "refId": "B",
+          "legendFormat": "p95"
+        },
+        {
+          "expr": "histogram_quantile(0.99, sum(rate(envoy_http_downstream_rq_time_bucket{job=\"envoy-global\",envoy_http_conn_manager_prefix=\"ingress_http\"}[5m])) by (le))",
+          "refId": "C",
+          "legendFormat": "p99"
+        }
+      ],
+      "options": {
+        "tooltip": { "mode": "multi", "sort": "desc" },
+        "legend": { "displayMode": "list", "placement": "bottom" }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ms",
+          "custom": { "lineWidth": 2, "fillOpacity": 10, "spanNulls": false }
+        },
+        "overrides": [
+          {
+            "matcher": { "id": "byName", "options": "p50" },
+            "properties": [{ "id": "color", "value": { "fixedColor": "green", "mode": "fixed" } }]
+          },
+          {
+            "matcher": { "id": "byName", "options": "p95" },
+            "properties": [{ "id": "color", "value": { "fixedColor": "yellow", "mode": "fixed" } }]
+          },
+          {
+            "matcher": { "id": "byName", "options": "p99" },
+            "properties": [{ "id": "color", "value": { "fixedColor": "red", "mode": "fixed" } }]
+          }
+        ]
+      }
+    },
+    {
+      "id": 8,
+      "type": "piechart",
+      "title": "Traffic Distribution by Zone",
+      "gridPos": { "x": 12, "y": 12, "w": 6, "h": 8 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "sum(rate(envoy_http_downstream_rq_total{job=\"envoy-zone1\",envoy_http_conn_manager_prefix=\"zone1_ingress\"}[5m]))",
+          "refId": "A",
+          "legendFormat": "zone1",
+          "instant": true
+        },
+        {
+          "expr": "sum(rate(envoy_http_downstream_rq_total{job=\"envoy-zone2\",envoy_http_conn_manager_prefix=\"zone2_ingress\"}[5m]))",
+          "refId": "B",
+          "legendFormat": "zone2",
+          "instant": true
+        }
+      ],
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"] },
+        "pieType": "donut",
+        "tooltip": { "mode": "single" },
+        "legend": { "displayMode": "list", "placement": "bottom" }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "color": { "mode": "palette-classic" }
+        },
+        "overrides": [
+          {
+            "matcher": { "id": "byName", "options": "zone1" },
+            "properties": [{ "id": "color", "value": { "fixedColor": "green", "mode": "fixed" } }]
+          },
+          {
+            "matcher": { "id": "byName", "options": "zone2" },
+            "properties": [{ "id": "color", "value": { "fixedColor": "orange", "mode": "fixed" } }]
+          }
+        ]
+      }
+    },
+    {
+      "id": 9,
+      "type": "timeseries",
+      "title": "Outlier Ejections (Failover Events)",
+      "gridPos": { "x": 18, "y": 12, "w": 6, "h": 8 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "sum(envoy_cluster_outlier_detection_ejections_active{job=\"envoy-global\",envoy_cluster_name=\"geo_cluster\"})",
+          "refId": "A",
+          "legendFormat": "active ejections (geo_cluster)"
+        },
+        {
+          "expr": "sum(rate(envoy_cluster_outlier_detection_ejections_enforced_total{job=\"envoy-zone1\",envoy_cluster_name=\"app_zone1_cluster\"}[1m]))",
+          "refId": "B",
+          "legendFormat": "enforced/s (zone1)"
+        },
+        {
+          "expr": "sum(rate(envoy_cluster_outlier_detection_ejections_enforced_total{job=\"envoy-zone2\",envoy_cluster_name=\"app_zone2_cluster\"}[1m]))",
+          "refId": "C",
+          "legendFormat": "enforced/s (zone2)"
+        }
+      ],
+      "options": {
+        "tooltip": { "mode": "multi" },
+        "legend": { "displayMode": "list", "placement": "bottom" }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "min": 0,
+          "custom": { "lineWidth": 2, "fillOpacity": 20, "drawStyle": "bars", "spanNulls": false }
+        },
+        "overrides": [
+          {
+            "matcher": { "id": "byName", "options": "active ejections (geo_cluster)" },
+            "properties": [
+              { "id": "color", "value": { "fixedColor": "red", "mode": "fixed" } },
+              { "id": "custom.drawStyle", "value": "line" }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "id": 10,
+      "type": "timeseries",
+      "title": "Active Upstream Connections",
+      "gridPos": { "x": 0, "y": 20, "w": 12, "h": 6 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "sum by (envoy_cluster_name) (envoy_cluster_upstream_cx_active{job=\"envoy-global\"})",
+          "refId": "A",
+          "legendFormat": "{{ envoy_cluster_name }}"
+        }
+      ],
+      "options": {
+        "tooltip": { "mode": "multi" },
+        "legend": { "displayMode": "list", "placement": "bottom" }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "min": 0,
+          "custom": { "lineWidth": 1, "fillOpacity": 10 }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 11,
+      "type": "timeseries",
+      "title": "Upstream Pending Requests",
+      "gridPos": { "x": 12, "y": 20, "w": 12, "h": 6 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "sum by (envoy_cluster_name) (envoy_cluster_upstream_rq_pending_active{job=\"envoy-global\"})",
+          "refId": "A",
+          "legendFormat": "{{ envoy_cluster_name }} pending"
+        }
+      ],
+      "options": {
+        "tooltip": { "mode": "multi" },
+        "legend": { "displayMode": "list", "placement": "bottom" }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "min": 0,
+          "custom": { "lineWidth": 1, "fillOpacity": 10 },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 10 },
+              { "color": "red", "value": 50 }
+            ]
+          }
+        },
+        "overrides": []
+      }
+    }
+  ]
+}

--- a/monitoring/grafana/provisioning/dashboards/dashboards.yml
+++ b/monitoring/grafana/provisioning/dashboards/dashboards.yml
@@ -1,0 +1,10 @@
+apiVersion: 1
+
+providers:
+  - name: 'geo-gateway'
+    type: file
+    disableDeletion: false
+    updateIntervalSeconds: 30
+    allowUiUpdates: true
+    options:
+      path: /var/lib/grafana/dashboards

--- a/monitoring/grafana/provisioning/datasources/prometheus.yml
+++ b/monitoring/grafana/provisioning/datasources/prometheus.yml
@@ -1,0 +1,12 @@
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    type: prometheus
+    uid: prometheus
+    url: http://prometheus:9090
+    access: proxy
+    isDefault: true
+    jsonData:
+      timeInterval: 15s
+      httpMethod: POST

--- a/monitoring/prometheus/prometheus.yml
+++ b/monitoring/prometheus/prometheus.yml
@@ -1,0 +1,38 @@
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+  external_labels:
+    system: geo-distributed-gateway
+
+alerting:
+  alertmanagers:
+    - static_configs:
+        - targets: ['alertmanager:9093']
+
+rule_files:
+  - /etc/prometheus/rules/*.yml
+
+scrape_configs:
+  # Global entry-point Envoy — collects cross-DC metrics (geo_cluster, ingress_http)
+  - job_name: 'envoy-global'
+    metrics_path: '/stats/prometheus'
+    static_configs:
+      - targets: ['global-envoy:9901']
+        labels:
+          envoy_instance: 'global'
+
+  # Zone 1 regional Envoy — collects zone1_ingress + app_zone1_cluster metrics
+  - job_name: 'envoy-zone1'
+    metrics_path: '/stats/prometheus'
+    static_configs:
+      - targets: ['zone1-envoy:9901']
+        labels:
+          envoy_instance: 'zone1'
+
+  # Zone 2 regional Envoy — collects zone2_ingress + app_zone2_cluster metrics
+  - job_name: 'envoy-zone2'
+    metrics_path: '/stats/prometheus'
+    static_configs:
+      - targets: ['zone2-envoy:9901']
+        labels:
+          envoy_instance: 'zone2'

--- a/monitoring/prometheus/rules/alerts.yml
+++ b/monitoring/prometheus/rules/alerts.yml
@@ -1,0 +1,145 @@
+groups:
+  - name: geo-gateway.traffic
+    interval: 15s
+    rules:
+
+      # ── Error Rate ────────────────────────────────────────────────────────────
+      # Runbook: error_rate > 5% на глобальном Envoy в течение 2 минут
+      - alert: HighErrorRate
+        expr: |
+          (
+            sum(rate(envoy_http_downstream_rq_xx{
+              job="envoy-global",
+              envoy_http_conn_manager_prefix="ingress_http",
+              envoy_response_code_class="5"
+            }[2m]))
+            /
+            sum(rate(envoy_http_downstream_rq_total{
+              job="envoy-global",
+              envoy_http_conn_manager_prefix="ingress_http"
+            }[2m]))
+          ) * 100 > 5
+        for: 2m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Error rate > 5% on global-envoy"
+          description: "5xx error rate is {{ printf \"%.1f\" $value }}% (threshold: 5%). Check Grafana: http://localhost:3000/d/traffic-geo"
+          runbook: "Runbook §1 — Высокий процент ошибок"
+
+      # ── Failover triggered ────────────────────────────────────────────────────
+      # Срабатывает когда outlier detection выбивает эндпоинты из geo_cluster
+      - alert: FailoverTriggered
+        expr: |
+          sum(envoy_cluster_outlier_detection_ejections_active{
+            job="envoy-global",
+            envoy_cluster_name="geo_cluster"
+          }) > 0
+        for: 30s
+        labels:
+          severity: warning
+        annotations:
+          summary: "Failover active — geo_cluster has ejected endpoints"
+          description: "{{ $value }} endpoint(s) ejected from geo_cluster. Traffic is being rerouted to the surviving DC."
+          runbook: "Runbook §2 — Failover сработал"
+
+      # ── p99 Latency ───────────────────────────────────────────────────────────
+      - alert: HighLatencyP99
+        expr: |
+          histogram_quantile(0.99,
+            sum(rate(envoy_http_downstream_rq_time_bucket{
+              job="envoy-global",
+              envoy_http_conn_manager_prefix="ingress_http"
+            }[5m])) by (le)
+          ) > 500
+        for: 2m
+        labels:
+          severity: warning
+        annotations:
+          summary: "p99 latency > 500ms on global-envoy"
+          description: "p99 latency is {{ printf \"%.0f\" $value }}ms (threshold: 500ms)."
+          runbook: "Runbook §5 — Высокая задержка"
+
+      # ── Critical latency ──────────────────────────────────────────────────────
+      - alert: CriticalLatencyP99
+        expr: |
+          histogram_quantile(0.99,
+            sum(rate(envoy_http_downstream_rq_time_bucket{
+              job="envoy-global",
+              envoy_http_conn_manager_prefix="ingress_http"
+            }[5m])) by (le)
+          ) > 1000
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: "p99 latency > 1000ms — rollback trigger"
+          description: "p99 latency is {{ printf \"%.0f\" $value }}ms. This exceeds the rollback threshold (1000ms)."
+          runbook: "Runbook §7 — Rollback"
+
+      # ── Low RPS ───────────────────────────────────────────────────────────────
+      # Может означать: трафик не доходит до шлюза, или все сервисы упали
+      - alert: LowRequestRate
+        expr: |
+          sum(rate(envoy_http_downstream_rq_total{
+            job="envoy-global",
+            envoy_http_conn_manager_prefix="ingress_http"
+          }[1m])) < 100
+        for: 2m
+        labels:
+          severity: warning
+        annotations:
+          summary: "RPS < 100 on global-envoy"
+          description: "Current RPS: {{ printf \"%.1f\" $value }}. Expected 300–700 RPS. Either traffic dropped or gateway is degraded."
+          runbook: "Runbook §1 — Высокий процент ошибок"
+
+      # ── High RPS ──────────────────────────────────────────────────────────────
+      - alert: HighRequestRate
+        expr: |
+          sum(rate(envoy_http_downstream_rq_total{
+            job="envoy-global",
+            envoy_http_conn_manager_prefix="ingress_http"
+          }[1m])) > 1200
+        for: 2m
+        labels:
+          severity: warning
+        annotations:
+          summary: "RPS > 1200 on global-envoy"
+          description: "Current RPS: {{ printf \"%.0f\" $value }} (SLA max: 1200 rps)."
+
+      # ── Zone health ───────────────────────────────────────────────────────────
+      # Prometheus не может скрейпить Envoy зоны — зона полностью недоступна
+      - alert: ZoneDown
+        expr: up{job=~"envoy-zone1|envoy-zone2"} == 0
+        for: 30s
+        labels:
+          severity: critical
+        annotations:
+          summary: "Zone Envoy {{ $labels.job }} is unreachable"
+          description: "Prometheus cannot scrape {{ $labels.instance }}. Zone Envoy is down."
+          runbook: "Runbook §4 — Полный отказ"
+
+  - name: geo-gateway.rollback
+    rules:
+      # Комбо-условие из Runbook §7: error > 10% + потеря запросов
+      - alert: RollbackRequired
+        expr: |
+          (
+            sum(rate(envoy_http_downstream_rq_xx{
+              job="envoy-global",
+              envoy_http_conn_manager_prefix="ingress_http",
+              envoy_response_code_class="5"
+            }[5m]))
+            /
+            sum(rate(envoy_http_downstream_rq_total{
+              job="envoy-global",
+              envoy_http_conn_manager_prefix="ingress_http"
+            }[5m]))
+          ) * 100 > 10
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: "ROLLBACK REQUIRED — error rate > 10% for 5 minutes"
+          description: "Error rate: {{ printf \"%.1f\" $value }}%. Trigger rollback: GEO_FAILOVER_ENABLED=false docker compose up -d zone1-envoy zone2-envoy global-envoy"
+          runbook: "Runbook §7 — Rollback"


### PR DESCRIPTION
## Что сделано

- Добавлен стек мониторинга: Prometheus, Grafana, Alertmanager
- Prometheus настроен на сбор метрик со всех сервисов и Envoy; добавлены правила алертов (высокий error rate, latency, недоступность зоны)
- Grafana развёрнута с готовым дашбордом `traffic-geo` и автопровижнингом datasource
- Alertmanager настроен с роутингом и группировкой по severity
- Credentials Grafana вынесены в `.env` (с дефолтом через `${VAR:-admin}`), пример добавлен в `.env.example`

## Проверка

- [ ] `make up` — стек поднимается, все healthcheck проходят
- [ ] Grafana доступна на `http://localhost:3000` (логин `admin/admin` по умолчанию)
- [ ] В Prometheus все таргеты в статусе UP
- [ ] `make traffic-gen` — метрики отображаются на дашборде
- [ ] `make failure-zone1` — алерт о падении зоны появляется в Alertmanager

🤖 Generated with [Claude Code](https://claude.ai/claude-code)