### PR TITLE
sdk client review fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@
 #
 # Build output
 bin/
+cmd/*/failure-runner
+cmd/*/traffic-gen
+app/service
 
 # Binaries for programs and plugins
 *.exe

--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/golang:1.22 AS builder
+FROM docker.io/golang:1.26 AS builder
 WORKDIR /src
 
 # Copy only the modules needed for the app service.
@@ -8,7 +8,7 @@ COPY sdk/ ./sdk/
 COPY app/ ./app/
 
 # Inline go.work so local replace resolves without external network.
-RUN printf 'go 1.22\n\nuse (\n\t./app\n\t./sdk\n)\n' > go.work && \
+RUN printf 'go 1.26\n\nuse (\n\t./app\n\t./sdk\n)\n' > go.work && \
     touch go.work.sum
 
 WORKDIR /src/app

--- a/app/cmd/service/main.go
+++ b/app/cmd/service/main.go
@@ -9,9 +9,11 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"sync/atomic"
 	"syscall"
 	"time"
 
+	"github.com/geo-distributed-gateway/sdk/config"
 	"github.com/geo-distributed-gateway/sdk/telemetry"
 )
 
@@ -29,6 +31,50 @@ func main() {
 	// Operational logs  → stderr (JSON, for log-aggregator / human consumption).
 	slog.SetDefault(slog.New(slog.NewJSONHandler(os.Stderr, nil)))
 
+	// currentCfg holds the live ServiceConfig, updated by the watcher goroutine.
+	// Zone from env is the baseline; config file can override it and other fields.
+	var currentCfg atomic.Value
+	currentCfg.Store(config.ServiceConfig{
+		Zone:           zone,
+		RequestTimeout: 5 * time.Second,
+		MaxRetries:     3,
+		RetryBackoff:   100 * time.Millisecond,
+	})
+
+	// Start config watcher if CONFIG_FILE is provided.
+	if cfgFile := os.Getenv("CONFIG_FILE"); cfgFile != "" {
+		w, err := config.NewWatcher(cfgFile, 5*time.Second)
+		if err != nil {
+			slog.Warn("config watcher not started", slog.String("file", cfgFile), slog.Any("err", err))
+		} else {
+			defer w.Close()
+
+			// Apply initial config: env zone wins if config has no zone override.
+			initial := w.Get()
+			if initial.Zone == "" {
+				initial.Zone = zone
+			}
+			currentCfg.Store(initial)
+
+			go func() {
+				for cfg := range w.Subscribe() {
+					prev := currentCfg.Load().(config.ServiceConfig)
+					if cfg.Zone == "" {
+						cfg.Zone = zone // keep env baseline if file clears the field
+					}
+					currentCfg.Store(cfg)
+					slog.Info("config reloaded",
+						slog.String("zone", cfg.Zone),
+						slog.Duration("request_timeout", cfg.RequestTimeout),
+						slog.Int("max_retries", cfg.MaxRetries),
+						slog.Duration("retry_backoff", cfg.RetryBackoff),
+						slog.String("prev_zone", prev.Zone),
+					)
+				}
+			}()
+		}
+	}
+
 	col := telemetry.New("stub-service", instance, zone, nil)
 	col.Start()
 	defer col.Stop()
@@ -40,32 +86,40 @@ func main() {
 			return // client disconnected or Envoy timed out before we started
 		}
 		start := time.Now()
+		cfg := currentCfg.Load().(config.ServiceConfig)
 		userID := r.Header.Get("X-User-ID")
 		cabinetID := r.Header.Get("X-Cabinet-ID")
 		correlationID := r.Header.Get("X-Correlation-ID")
 
 		slog.Info("GET /ping",
 			slog.String("instance", instance),
+			slog.String("zone", cfg.Zone),
 			slog.String("user_id", userID),
 			slog.String("cabinet_id", cabinetID),
 			slog.String("correlation_id", correlationID),
 		)
 
 		w.Header().Set("X-Served-By", instance)
-		w.Header().Set("X-Zone", zone)
+		w.Header().Set("X-Zone", cfg.Zone)
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, "pong: %s (zone=%s)", instance, zone)
+		fmt.Fprintf(w, "pong: %s (zone=%s)", instance, cfg.Zone)
 
 		col.Request(userID, cabinetID, correlationID, http.StatusOK, time.Since(start))
 	})
 
 	mux.HandleFunc("GET /health", func(w http.ResponseWriter, r *http.Request) {
+		cfg := currentCfg.Load().(config.ServiceConfig)
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		json.NewEncoder(w).Encode(map[string]string{
+		json.NewEncoder(w).Encode(map[string]any{
 			"status":   "ok",
 			"instance": instance,
-			"zone":     zone,
+			"zone":     cfg.Zone,
+			"config": map[string]any{
+				"request_timeout": cfg.RequestTimeout.String(),
+				"max_retries":     cfg.MaxRetries,
+				"retry_backoff":   cfg.RetryBackoff.String(),
+			},
 		})
 	})
 

--- a/app/cmd/service/main.go
+++ b/app/cmd/service/main.go
@@ -1,12 +1,15 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
-	"log"
 	"log/slog"
 	"net/http"
 	"os"
+	"os/signal"
+	"syscall"
 	"time"
 
 	"github.com/geo-distributed-gateway/sdk/telemetry"
@@ -22,6 +25,10 @@ func main() {
 		zone = "unknown"
 	}
 
+	// Telemetry events  → stdout (JSON Lines, consumed by Events Collector).
+	// Operational logs  → stderr (JSON, for log-aggregator / human consumption).
+	slog.SetDefault(slog.New(slog.NewJSONHandler(os.Stderr, nil)))
+
 	col := telemetry.New("stub-service", instance, zone, nil)
 	col.Start()
 	defer col.Stop()
@@ -29,6 +36,9 @@ func main() {
 	mux := http.NewServeMux()
 
 	mux.HandleFunc("GET /ping", func(w http.ResponseWriter, r *http.Request) {
+		if err := r.Context().Err(); err != nil {
+			return // client disconnected or Envoy timed out before we started
+		}
 		start := time.Now()
 		userID := r.Header.Get("X-User-ID")
 		cabinetID := r.Header.Get("X-Cabinet-ID")
@@ -59,9 +69,27 @@ func main() {
 		})
 	})
 
-	addr := ":8080"
-	slog.Info("Starting stub service", slog.String("addr", addr), slog.String("instance", instance))
-	if err := http.ListenAndServe(addr, mux); err != nil {
-		log.Fatal(err)
+	srv := &http.Server{
+		Addr:    ":8080",
+		Handler: mux,
+	}
+
+	go func() {
+		slog.Info("Starting stub service", slog.String("addr", srv.Addr), slog.String("instance", instance))
+		if err := srv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			slog.Error("server error", slog.Any("err", err))
+			os.Exit(1)
+		}
+	}()
+
+	quit := make(chan os.Signal, 1)
+	signal.Notify(quit, syscall.SIGTERM, syscall.SIGINT)
+	<-quit
+
+	slog.Info("Shutting down", slog.String("instance", instance))
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	if err := srv.Shutdown(ctx); err != nil {
+		slog.Error("shutdown error", slog.Any("err", err))
 	}
 }

--- a/app/config/service.json
+++ b/app/config/service.json
@@ -1,0 +1,5 @@
+{
+  "request_timeout": "5s",
+  "max_retries": 3,
+  "retry_backoff": "100ms"
+}

--- a/app/go.mod
+++ b/app/go.mod
@@ -1,6 +1,6 @@
-module geo-distributed-app
+module github.com/geo-distributed-gateway/app
 
-go 1.22
+go 1.26
 
 require github.com/geo-distributed-gateway/sdk v0.0.0
 

--- a/cmd/failure-runner/Dockerfile
+++ b/cmd/failure-runner/Dockerfile
@@ -18,7 +18,6 @@ COPY --from=builder /out/failure-runner /usr/local/bin/failure-runner
 # Default probe URL uses compose service name; socket is mounted at runtime.
 # docker compose run failure-runner zone1-full
 ENTRYPOINT ["failure-runner", \
-  "-runtime",   "docker", \
-  "-probe-url", "http://global-envoy:10000/ping", \
-  "-admin1",    "http://zone1-envoy:9901", \
-  "-admin2",    "http://zone2-envoy:9901"]
+  "-runtime",    "docker", \
+  "-probe-url",  "http://global-envoy:10000/ping", \
+  "-prometheus", "http://prometheus:9090"]

--- a/cmd/failure-runner/Dockerfile
+++ b/cmd/failure-runner/Dockerfile
@@ -1,10 +1,10 @@
-FROM golang:1.22 AS builder
+FROM golang:1.26 AS builder
 WORKDIR /src
 
 COPY sdk/ ./sdk/
 COPY cmd/failure-runner/ ./cmd/failure-runner/
 
-RUN printf 'go 1.22\n\nuse (\n\t./cmd/failure-runner\n\t./sdk\n)\n' > go.work && \
+RUN printf 'go 1.26\n\nuse (\n\t./cmd/failure-runner\n\t./sdk\n)\n' > go.work && \
     touch go.work.sum
 
 WORKDIR /src/cmd/failure-runner

--- a/cmd/failure-runner/go.mod
+++ b/cmd/failure-runner/go.mod
@@ -1,6 +1,6 @@
 module github.com/geo-distributed-gateway/failure-runner
 
-go 1.22
+go 1.26
 
 require github.com/geo-distributed-gateway/sdk v0.0.0
 

--- a/cmd/failure-runner/main.go
+++ b/cmd/failure-runner/main.go
@@ -1,6 +1,6 @@
 // failure-runner orchestrates failure injection scenarios against the geo-distributed gateway.
 // It uses the container runtime CLI (podman/docker stop/start/pause/unpause)
-// and collects Envoy admin metrics before and after each scenario to measure impact.
+// and queries Prometheus before and after each scenario to measure impact.
 //
 // Usage:
 //
@@ -20,23 +20,26 @@
 // Flags:
 //
 //	-runtime        Container runtime: podman or docker (default: podman)
-//	-admin1         Zone1 Envoy admin URL (default: http://localhost:19001)
-//	-admin2         Zone2 Envoy admin URL (default: http://localhost:19002)
+//	-prometheus     Prometheus base URL (default: http://localhost:9090)
 //	-restore-after  Auto-restore containers after this duration (0 = manual, default: 30s)
 //	-probe-url      Gateway URL to probe during scenario (default: http://localhost:10000/ping)
 //	-probe-rps      Probe RPS during scenario (default: 20)
+//	-zone           Zone containers: -zone name=c1,c2 (repeatable, any number of zones)
 package main
 
 import (
 	"context"
+	"encoding/json"
 	"flag"
 	"fmt"
-	"io"
+	"math"
 	"net/http"
 	"net/url"
 	"os"
 	"os/exec"
 	"os/signal"
+	"sort"
+	"strconv"
 	"strings"
 	"syscall"
 	"time"
@@ -45,10 +48,30 @@ import (
 	"github.com/geo-distributed-gateway/sdk/stats"
 )
 
-// zone container groups known to docker-compose.
-var zoneContainers = map[string][]string{
-	"zone1": {"app-zone1-1", "app-zone1-2"},
-	"zone2": {"app-zone2-1", "app-zone2-2"},
+// zonesFlag is a repeatable -zone flag that builds a map of zone → containers.
+// Each use has the form:  -zone name=container1,container2
+type zonesFlag map[string][]string
+
+func (z zonesFlag) String() string {
+	keys := make([]string, 0, len(z))
+	for k := range z {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	parts := make([]string, 0, len(z))
+	for _, k := range keys {
+		parts = append(parts, k+"="+strings.Join(z[k], ","))
+	}
+	return strings.Join(parts, "; ")
+}
+
+func (z zonesFlag) Set(s string) error {
+	name, list, ok := strings.Cut(s, "=")
+	if !ok || name == "" || list == "" {
+		return fmt.Errorf("want zone=container1,container2, got %q", s)
+	}
+	z[name] = strings.Split(list, ",")
+	return nil
 }
 
 type scenario struct {
@@ -69,12 +92,16 @@ var scenarios = map[string]scenario{
 }
 
 func main() {
-	runtime := flag.String("runtime", "podman", "Container runtime: podman or docker")
-	admin1 := flag.String("admin1", "http://localhost:19001", "Zone1 Envoy admin URL")
-	admin2 := flag.String("admin2", "http://localhost:19002", "Zone2 Envoy admin URL")
+	runtime      := flag.String("runtime", "podman", "Container runtime: podman or docker")
+	prometheusURL := flag.String("prometheus", "http://localhost:9090", "Prometheus base URL")
 	restoreAfter := flag.Duration("restore-after", 30*time.Second, "Auto-restore after duration (0 = manual)")
-	probeURL := flag.String("probe-url", "http://localhost:10000/ping", "Gateway URL to probe during scenario")
-	probeRPS := flag.Int("probe-rps", 20, "Probe requests per second during scenario")
+	probeURL     := flag.String("probe-url", "http://localhost:10000/ping", "Gateway URL to probe during scenario")
+	probeRPS     := flag.Int("probe-rps", 20, "Probe requests per second during scenario")
+	zones := zonesFlag{
+		"zone1": {"app-zone1-1", "app-zone1-2"},
+		"zone2": {"app-zone2-1", "app-zone2-2"},
+	}
+	flag.Var(zones, "zone", "Zone containers: -zone name=c1,c2 (repeatable)")
 	flag.Parse()
 
 	if flag.NArg() == 0 {
@@ -98,8 +125,8 @@ func main() {
 
 	// --- Phase 1: Baseline metrics ---
 	fmt.Println("--- Baseline (before failure) ---")
-	baseline := collectEnvoyStats(*admin1, *admin2)
-	printStats("baseline", baseline)
+	baseline, baseAvail := collectGatewayStats(*prometheusURL)
+	printGatewayStats("baseline", baseline, baseAvail)
 
 	baseRec := &stats.Recorder{}
 	probeFor(ctx, *probeURL, *probeRPS, 10*time.Second, baseRec)
@@ -107,7 +134,7 @@ func main() {
 	fmt.Printf("baseline probe: %s\n\n", baseSnap.Report(10*time.Second))
 
 	// --- Phase 2: Inject failure ---
-	containers := targetContainers(sc)
+	containers := targetContainers(sc, zones)
 	fmt.Printf("--- Injecting failure: %v ---\n", containers)
 	if err := injectFailure(*runtime, containers, sc.pause); err != nil {
 		fmt.Fprintf(os.Stderr, "failed to inject: %v\n", err)
@@ -135,24 +162,27 @@ func main() {
 	// --- Phase 5: Post-restore metrics ---
 	time.Sleep(3 * time.Second) // give Envoy time to see healthy upstreams
 	fmt.Println("\n--- Post-restore (after failover + recovery) ---")
-	postStats := collectEnvoyStats(*admin1, *admin2)
-	printStats("post-restore", postStats)
+	postStats, postAvail := collectGatewayStats(*prometheusURL)
+	printGatewayStats("post-restore", postStats, postAvail)
 
 	// --- Summary ---
 	fmt.Printf("\n=== Summary: %s ===\n", sc.name)
 	fmt.Printf("baseline   : %s\n", baseSnap.Report(10*time.Second))
 	fmt.Printf("during fail: %s\n", failureSnap.Report(probeDur))
+	if postAvail {
+		fmt.Printf("post-restore (Prometheus): error_rate=%.2f%%  zone1_rps=%.1f  zone2_rps=%.1f  ejections=%.0f\n",
+			postStats.errorRatePct, postStats.zone1RPS, postStats.zone2RPS, postStats.ejections)
+	}
 	fmt.Printf("\nExpected: error_rate < 5%% (failover kicks in within Envoy retry window)\n")
 	if failureSnap.ErrorRate() < 5.0 {
 		fmt.Println("PASS: error rate within SLA during failure")
 	} else {
 		fmt.Printf("FAIL: error rate %.2f%% exceeds 5%% threshold\n", failureSnap.ErrorRate())
 	}
-
 }
 
-func targetContainers(sc scenario) []string {
-	all := zoneContainers[sc.zone]
+func targetContainers(sc scenario, zones zonesFlag) []string {
+	all := zones[sc.zone]
 	if sc.partial && len(all) > 1 {
 		return all[:len(all)/2]
 	}
@@ -184,8 +214,8 @@ func restoreContainers(runtime string, containers []string, wasPaused bool) erro
 }
 
 // probeFor sends requests at rps for dur and records results into rec.
-func probeFor(ctx context.Context, url string, rps int, dur time.Duration, rec *stats.Recorder) {
-	u, err := url.Parse(url)
+func probeFor(ctx context.Context, rawURL string, rps int, dur time.Duration, rec *stats.Recorder) {
+	u, err := url.Parse(rawURL)
 	if err != nil || u.Host == "" {
 		u = &url.URL{Scheme: "http", Host: "localhost:10000", Path: "/ping"}
 	}
@@ -218,41 +248,84 @@ func probeFor(ctx context.Context, url string, rps int, dur time.Duration, rec *
 	}
 }
 
-type envoyStats struct {
-	zone1RX, zone2RX string // raw /stats output snippet
+// gatewayStats holds a point-in-time snapshot of key gateway metrics from Prometheus.
+type gatewayStats struct {
+	errorRatePct float64 // global 5xx error rate, percent
+	zone1RPS     float64 // inbound RPS on zone1-envoy
+	zone2RPS     float64 // inbound RPS on zone2-envoy
+	ejections    float64 // active outlier-detection ejections in geo_cluster
 }
 
-func collectEnvoyStats(admin1, admin2 string) envoyStats {
-	return envoyStats{
-		zone1RX: fetchAdminStats(admin1),
-		zone2RX: fetchAdminStats(admin2),
-	}
-}
-
-func fetchAdminStats(adminURL string) string {
-	resp, err := http.Get(adminURL + "/stats?filter=upstream_rq_total")
+// collectGatewayStats queries Prometheus for current gateway metrics.
+// Returns (stats, false) if Prometheus is unreachable.
+func collectGatewayStats(prometheusURL string) (gatewayStats, bool) {
+	// Availability check before running queries.
+	resp, err := http.Get(prometheusURL + "/-/healthy")
 	if err != nil {
-		return fmt.Sprintf("(unavailable: %v)", err)
+		return gatewayStats{}, false
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return gatewayStats{}, false
+	}
+
+	errRate, _ := queryPrometheus(prometheusURL,
+		`sum(rate(envoy_http_downstream_rq_xx{job="envoy-global",envoy_http_conn_manager_prefix="ingress_http",envoy_response_code_class="5"}[1m]))`+
+			` / sum(rate(envoy_http_downstream_rq_total{job="envoy-global",envoy_http_conn_manager_prefix="ingress_http"}[1m])) * 100`)
+	z1rps, _ := queryPrometheus(prometheusURL,
+		`sum(rate(envoy_http_downstream_rq_total{job="envoy-zone1",envoy_http_conn_manager_prefix="zone1_ingress"}[1m]))`)
+	z2rps, _ := queryPrometheus(prometheusURL,
+		`sum(rate(envoy_http_downstream_rq_total{job="envoy-zone2",envoy_http_conn_manager_prefix="zone2_ingress"}[1m]))`)
+	ejections, _ := queryPrometheus(prometheusURL,
+		`sum(envoy_cluster_outlier_detection_ejections_active{job="envoy-global",envoy_cluster_name="geo_cluster"})`)
+
+	return gatewayStats{
+		errorRatePct: errRate,
+		zone1RPS:     z1rps,
+		zone2RPS:     z2rps,
+		ejections:    ejections,
+	}, true
+}
+
+// queryPrometheus runs an instant PromQL query and returns the scalar result.
+// Returns (0, false) if the query returns no data or the value is NaN/Inf.
+func queryPrometheus(baseURL, query string) (float64, bool) {
+	resp, err := http.Get(baseURL + "/api/v1/query?query=" + url.QueryEscape(query))
+	if err != nil {
+		return 0, false
 	}
 	defer resp.Body.Close()
-	b, _ := io.ReadAll(resp.Body)
-	return strings.TrimSpace(string(b))
+
+	var r struct {
+		Status string `json:"status"`
+		Data   struct {
+			Result []struct {
+				Value [2]json.RawMessage `json:"value"`
+			} `json:"result"`
+		} `json:"data"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&r); err != nil || r.Status != "success" || len(r.Data.Result) == 0 {
+		return 0, false
+	}
+
+	var s string
+	if err := json.Unmarshal(r.Data.Result[0].Value[1], &s); err != nil {
+		return 0, false
+	}
+	v, err := strconv.ParseFloat(s, 64)
+	if err != nil || math.IsNaN(v) || math.IsInf(v, 0) {
+		return 0, false
+	}
+	return v, true
 }
 
-func printStats(label string, s envoyStats) {
-	fmt.Printf("[%s] zone1-envoy stats:\n%s\n", label, indent(s.zone1RX))
-	fmt.Printf("[%s] zone2-envoy stats:\n%s\n\n", label, indent(s.zone2RX))
-}
-
-func indent(s string) string {
-	if s == "" {
-		return "  (no data)"
+func printGatewayStats(label string, s gatewayStats, available bool) {
+	if !available {
+		fmt.Printf("[%s] Prometheus unavailable — gateway stats not collected\n\n", label)
+		return
 	}
-	lines := strings.Split(s, "\n")
-	for i, l := range lines {
-		lines[i] = "  " + l
-	}
-	return strings.Join(lines, "\n")
+	fmt.Printf("[%s] error_rate=%.2f%%  zone1_rps=%.1f  zone2_rps=%.1f  ejections=%.0f\n\n",
+		label, s.errorRatePct, s.zone1RPS, s.zone2RPS, s.ejections)
 }
 
 func printUsage() {

--- a/cmd/failure-runner/main.go
+++ b/cmd/failure-runner/main.go
@@ -33,6 +33,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"os"
 	"os/exec"
 	"os/signal"
@@ -184,11 +185,13 @@ func restoreContainers(runtime string, containers []string, wasPaused bool) erro
 
 // probeFor sends requests at rps for dur and records results into rec.
 func probeFor(ctx context.Context, url string, rps int, dur time.Duration, rec *stats.Recorder) {
-	c := client.New(client.Options{BaseURL: strings.TrimSuffix(url, "/ping"), Timeout: 5 * time.Second})
-	path := "/ping"
-	if idx := strings.LastIndex(url, "/"); idx >= 0 {
-		path = url[idx:]
+	u, err := url.Parse(url)
+	if err != nil || u.Host == "" {
+		u = &url.URL{Scheme: "http", Host: "localhost:10000", Path: "/ping"}
 	}
+	path := u.Path
+	baseURL := u.Scheme + "://" + u.Host
+	c := client.New(client.Options{BaseURL: baseURL, Timeout: 5 * time.Second})
 
 	ticker := time.NewTicker(time.Second / time.Duration(rps))
 	defer ticker.Stop()

--- a/cmd/traffic-gen/Dockerfile
+++ b/cmd/traffic-gen/Dockerfile
@@ -1,10 +1,10 @@
-FROM golang:1.22 AS builder
+FROM golang:1.26 AS builder
 WORKDIR /src
 
 COPY sdk/ ./sdk/
 COPY cmd/traffic-gen/ ./cmd/traffic-gen/
 
-RUN printf 'go 1.22\n\nuse (\n\t./cmd/traffic-gen\n\t./sdk\n)\n' > go.work && \
+RUN printf 'go 1.26\n\nuse (\n\t./cmd/traffic-gen\n\t./sdk\n)\n' > go.work && \
     touch go.work.sum
 
 WORKDIR /src/cmd/traffic-gen

--- a/cmd/traffic-gen/go.mod
+++ b/cmd/traffic-gen/go.mod
@@ -1,6 +1,6 @@
 module github.com/geo-distributed-gateway/traffic-gen
 
-go 1.22
+go 1.26
 
 require github.com/geo-distributed-gateway/sdk v0.0.0
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,9 @@ services:
     environment:
       - INSTANCE_NAME=zone1-1
       - ZONE=zone1
+      - CONFIG_FILE=/etc/service/config.json
+    volumes:
+      - ./app/config/service.json:/etc/service/config.json:ro
     networks:
       - zone1-net
     healthcheck:
@@ -27,6 +30,9 @@ services:
     environment:
       - INSTANCE_NAME=zone1-2
       - ZONE=zone1
+      - CONFIG_FILE=/etc/service/config.json
+    volumes:
+      - ./app/config/service.json:/etc/service/config.json:ro
     networks:
       - zone1-net
     healthcheck:
@@ -75,6 +81,9 @@ services:
     environment:
       - INSTANCE_NAME=zone2-1
       - ZONE=zone2
+      - CONFIG_FILE=/etc/service/config.json
+    volumes:
+      - ./app/config/service.json:/etc/service/config.json:ro
     networks:
       - zone2-net
     healthcheck:
@@ -92,6 +101,9 @@ services:
     environment:
       - INSTANCE_NAME=zone2-2
       - ZONE=zone2
+      - CONFIG_FILE=/etc/service/config.json
+    volumes:
+      - ./app/config/service.json:/etc/service/config.json:ro
     networks:
       - zone2-net
     healthcheck:

--- a/docs/API-Reference.md
+++ b/docs/API-Reference.md
@@ -4,7 +4,7 @@
 |---|---|
 | **Версия API** | v1 |
 | **Base URL** | `http://localhost:10000` (локальный стенд через global-envoy) |
-| **Обновлено** | 2026-04-05 |
+| **Обновлено** | 2026-04-12 |
 
 ---
 
@@ -94,7 +94,12 @@ Host: localhost:10000
 {
   "status": "ok",
   "instance": "zone1-1",
-  "zone": "zone1"
+  "zone": "zone1",
+  "config": {
+    "request_timeout": "5s",
+    "max_retries": 3,
+    "retry_backoff": "100ms"
+  }
 }
 ```
 
@@ -102,7 +107,10 @@ Host: localhost:10000
 |---|---|---|
 | `status` | string | Всегда `"ok"` при живом инстансе |
 | `instance` | string | Имя инстанса |
-| `zone` | string | Зона инстанса |
+| `zone` | string | Текущая зона (может быть переопределена через config watcher) |
+| `config.request_timeout` | string | Текущий таймаут запроса |
+| `config.max_retries` | int | Текущее максимальное число повторов |
+| `config.retry_backoff` | string | Текущая задержка между повторами |
 
 ---
 
@@ -152,12 +160,7 @@ result, err := c.DoWithHeaders(ctx, "/ping", "user-1", "cabinet-5", map[string]s
 ```go
 import "github.com/geo-distributed-gateway/sdk/telemetry"
 
-col := telemetry.New(telemetry.Options{
-    Service:  "app",
-    Instance: "zone1-1",
-    Zone:     "zone1",
-})
-
+col := telemetry.New("app", "zone1-1", "zone1", nil) // nil → stdout
 col.Start()
 col.Request("user-1", "cabinet-5", correlationID, 200, 12*time.Millisecond)
 col.Error(correlationID, "timeout")
@@ -227,14 +230,14 @@ w.Close()
 ```go
 import "github.com/geo-distributed-gateway/sdk/stats"
 
-rec := stats.NewRecorder()
+rec := &stats.Recorder{}
 rec.Add(12*time.Millisecond, false)
-rec.Add(250*time.Millisecond, true) // isError=true
+rec.Add(250*time.Millisecond, true) // isError=true; latency ошибок не включается в гистограмму
 
 snap := rec.Snapshot()
-fmt.Println(snap.P50, snap.P95, snap.P99)
+fmt.Println(snap.P50(), snap.P95(), snap.P99())
 fmt.Println(snap.ErrorRate())
-fmt.Println(snap.Report(5 * time.Second)) // "total=2 success=1 errors=1 error_rate=50.00% rps=0.40 p50=12ms p95=250ms p99=250ms"
+fmt.Println(snap.Report(5 * time.Second)) // "total=2 success=1 errors=1 error_rate=50.00% rps=0.40 p50=12ms p95=12ms p99=12ms"
 
 rec.Reset() // сбросить для следующего окна
 ```
@@ -243,12 +246,25 @@ rec.Reset() // сбросить для следующего окна
 
 ## Envoy Admin API
 
-Используется `failure-runner` для сбора статистики.
+Доступен для ручной диагностики и используется Prometheus для scraping метрик.
 
 | URL | Описание |
 |---|---|
-| `http://localhost:19000/stats?filter=upstream_rq_total` | Статистика global-envoy |
-| `http://localhost:19001/stats?filter=upstream_rq_total` | Статистика zone1-envoy |
-| `http://localhost:19002/stats?filter=upstream_rq_total` | Статистика zone2-envoy |
+| `http://localhost:19000` | Admin UI global-envoy |
+| `http://localhost:19001` | Admin UI zone1-envoy |
+| `http://localhost:19002` | Admin UI zone2-envoy |
 
-Порты: `19000` — global-envoy, `19001` — zone1-envoy, `19002` — zone2-envoy.
+Полезные эндпоинты: `/stats`, `/clusters`, `/config_dump`, `/ready`.
+
+## Prometheus API
+
+`failure-runner` собирает статистику через Prometheus HTTP API (`-prometheus` флаг, default: `http://localhost:9090`).
+
+Используемые PromQL-запросы:
+
+| Метрика | Запрос |
+|---|---|
+| Error rate (%) | `sum(rate(envoy_http_downstream_rq_xx{job="envoy-global",...,envoy_response_code_class="5"}[1m])) / sum(rate(envoy_http_downstream_rq_total{...}[1m])) * 100` |
+| Zone1 RPS | `sum(rate(envoy_http_downstream_rq_total{job="envoy-zone1",...}[1m]))` |
+| Zone2 RPS | `sum(rate(envoy_http_downstream_rq_total{job="envoy-zone2",...}[1m]))` |
+| Активные ejections | `sum(envoy_cluster_outlier_detection_ejections_active{job="envoy-global",envoy_cluster_name="geo_cluster"})` |

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -23,7 +23,7 @@ if [ -z "${CONTAINER_RUNTIME:-}" ]; then
   fi
 fi
 
-GO_IMAGE="golang:1.22"
+GO_IMAGE="golang:1.26"
 
 # Detect host platform for cross-compilation.
 HOST_OS="$(uname -s | tr '[:upper:]' '[:lower:]')"

--- a/sdk/client/client.go
+++ b/sdk/client/client.go
@@ -30,6 +30,9 @@ func (o *Options) defaults() {
 	}
 	if o.HTTPClient == nil {
 		o.HTTPClient = &http.Client{Timeout: o.Timeout}
+	} else {
+		// Apply Timeout to the provided client; transport and other settings are preserved.
+		o.HTTPClient.Timeout = o.Timeout
 	}
 }
 

--- a/sdk/go.mod
+++ b/sdk/go.mod
@@ -1,3 +1,3 @@
 module github.com/geo-distributed-gateway/sdk
 
-go 1.22
+go 1.26

--- a/sdk/stats/stats.go
+++ b/sdk/stats/stats.go
@@ -20,6 +20,8 @@ type Recorder struct {
 }
 
 // Add records a single result.
+// Error latencies are intentionally excluded from the histogram so that
+// percentiles (P50/P95/P99) reflect only successful request timings.
 func (r *Recorder) Add(latency time.Duration, isError bool) {
 	r.mu.Lock()
 	r.total++

--- a/sdk/telemetry/telemetry.go
+++ b/sdk/telemetry/telemetry.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"io"
 	"os"
+	"sync"
 	"time"
 )
 
@@ -37,12 +38,14 @@ type Event struct {
 }
 
 // Collector publishes events to an io.Writer as JSON lines.
+// All methods are safe for concurrent use.
 type Collector struct {
 	service  string
 	instance string
 	zone     string
 	out      io.Writer
 	enc      *json.Encoder
+	mu       sync.Mutex
 }
 
 // New creates a Collector for a service.
@@ -70,6 +73,8 @@ func (c *Collector) emit(e Event) {
 	if e.Timestamp.IsZero() {
 		e.Timestamp = time.Now().UTC()
 	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
 	_ = c.enc.Encode(e) // best-effort; logging failures are non-fatal
 }
 


### PR DESCRIPTION
- Connect sdk/config.Watcher to app service: hot-reload via CONFIG_FILE env var; all ServiceConfig fields (Zone, RequestTimeout, MaxRetries, RetryBackoff) stored in atomic.Value and exposed via /health
- Replace hardcoded zoneContainers with repeatable -zone flag (zonesFlag type); supports arbitrary number of zones without recompilation
- Replace failure-runner Envoy Admin API with Prometheus HTTP API; update Dockerfile entrypoint accordingly
- Add app/config/service.json default config file; mount in compose
- docs: update API Reference to reflect review fixes
- /health response now includes config section
- Fix telemetry.New() constructor signature in examples
- Fix stats.Recorder usage (no constructor, P50/P95/P99 are methods)
- Replace stale Envoy Admin API note with Prometheus API section